### PR TITLE
fix: gracefully skip frontend/extension install if package.json missing

### DIFF
--- a/scripts/install_dev_tools.sh
+++ b/scripts/install_dev_tools.sh
@@ -158,14 +158,18 @@ echo "Step 6: Installing Frontend Dependencies"
 echo "--------------------------------------------------"
 cd src/frontend
 
-print_info "Installing Node.js dependencies with pnpm..."
-pnpm install
-
-if [ $? -eq 0 ]; then
-    print_status "Frontend dependencies installed successfully"
+if [ -f "package.json" ]; then
+    print_info "Installing Node.js dependencies with pnpm..."
+    pnpm install
+    
+    if [ $? -eq 0 ]; then
+        print_status "Frontend dependencies installed successfully"
+    else
+        print_error "Frontend dependency installation failed"
+        exit 1
+    fi
 else
-    print_error "Frontend dependency installation failed"
-    exit 1
+    print_info "No package.json found - frontend not set up yet (skipping)"
 fi
 
 cd ../..
@@ -175,14 +179,18 @@ echo "Step 7: Installing Browser Extension Dependencies"
 echo "--------------------------------------------------"
 cd src/extension
 
-print_info "Installing extension dependencies with npm..."
-npm install
-
-if [ $? -eq 0 ]; then
-    print_status "Extension dependencies installed successfully"
+if [ -f "package.json" ]; then
+    print_info "Installing extension dependencies with npm..."
+    npm install
+    
+    if [ $? -eq 0 ]; then
+        print_status "Extension dependencies installed successfully"
+    else
+        print_error "Extension dependency installation failed"
+        exit 1
+    fi
 else
-    print_error "Extension dependency installation failed"
-    exit 1
+    print_info "No package.json found - extension not set up yet (skipping)"
 fi
 
 cd ../..


### PR DESCRIPTION
Frontend and extension are not set up yet, so installation script now checks for package.json existence before attempting to install dependencies.

## Description
Please provide a clear and concise description of the changes in this PR.

## Related Issues
Fixes #(issue number)
Related to #(issue number)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates

## Changes Made
Please describe the changes made in this PR:
- Change 1
- Change 2
- Change 3

## Testing
Please describe the tests that you ran to verify your changes:
- [ ] Test 1
- [ ] Test 2
- [ ] Test 3

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
Add screenshots to help reviewers understand your changes.

## Additional Notes
Any additional information or context that reviewers should know.
