### PR TITLE
fix: remove types-all from mypy dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,9 +25,10 @@ repos:
       - id: mypy
         args: [--strict, --ignore-missing-imports]
         additional_dependencies: 
-          - types-all
-          - pydantic
-          - sqlalchemy
+          - pydantic>=2.5.0
+          - sqlalchemy>=2.0.0
+          - types-redis
+          - types-passlib
         files: ^src/backend/app/
         exclude: ^src/backend/tests/
 


### PR DESCRIPTION
The types-all package has conflicts and yanked versions. Replaced with specific type stubs we actually need: pydantic, sqlalchemy, types-redis, types-passlib.

## Description
Please provide a clear and concise description of the changes in this PR.

## Related Issues
Fixes #(issue number)
Related to #(issue number)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates

## Changes Made
Please describe the changes made in this PR:
- Change 1
- Change 2
- Change 3

## Testing
Please describe the tests that you ran to verify your changes:
- [ ] Test 1
- [ ] Test 2
- [ ] Test 3

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
Add screenshots to help reviewers understand your changes.

## Additional Notes
Any additional information or context that reviewers should know.
