### PR TITLE
fix: make frontend checks optional in quick_check.sh

### DIFF
--- a/scripts/quick_check.sh
+++ b/scripts/quick_check.sh
@@ -63,22 +63,26 @@ else
     ERRORS=$((ERRORS + 1))
 fi
 
-# Check frontend dependencies  
-if [ -d "src/frontend/node_modules" ]; then
-    echo "✓ Frontend dependencies installed"
+# Check frontend dependencies (optional - not set up yet)
+if [ -f "src/frontend/package.json" ]; then
+    if [ -d "src/frontend/node_modules" ]; then
+        echo "✓ Frontend dependencies installed"
+    else
+        echo "⚠ Frontend dependencies missing - run: cd src/frontend && pnpm install"
+        echo "  (Optional: frontend not set up yet)"
+    fi
 else
-    echo "✗ Frontend dependencies missing - run: cd src/frontend && pnpm install"
-    ERRORS=$((ERRORS + 1))
+    echo "⚠ Frontend not set up yet (optional)"
 fi
 
 echo ""
 echo "======================="
 if [ $ERRORS -eq 0 ]; then
-    echo "✓ All checks passed!"
+    echo "✓ All critical checks passed!"
     echo "Ready to start development"
     exit 0
 else
-    echo "✗ $ERRORS checks failed"
+    echo "✗ $ERRORS critical checks failed"
     echo "See scripts/INSTALLATION_ORDER.md for setup steps"
     exit 1
 fi


### PR DESCRIPTION
Frontend is not set up yet, so this check should be optional and not cause the script to fail. Changed to warning () instead of error ().

## Description
Please provide a clear and concise description of the changes in this PR.

## Related Issues
Fixes #(issue number)
Related to #(issue number)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates

## Changes Made
Please describe the changes made in this PR:
- Change 1
- Change 2
- Change 3

## Testing
Please describe the tests that you ran to verify your changes:
- [ ] Test 1
- [ ] Test 2
- [ ] Test 3

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
Add screenshots to help reviewers understand your changes.

## Additional Notes
Any additional information or context that reviewers should know.
